### PR TITLE
No longer run tests under Python 3.8

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -18,11 +18,11 @@ jobs:
         # https://github.com/actions/python-versions/blob/main/versions-manifest.json
         # https://devguide.python.org/versions/
         python-version:
-        - "3.8"
         - "3.9"
         - "3.10"
         - "3.11"
         - "3.12"
+        - "3.13.0-rc.2"
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
It will reach "End of life" in October + add 3.13 Release Candidate (to be released in a few weeks).

> Pylint 3.3.0 dropped support for Py3.8 / see #207